### PR TITLE
Link to mail config from mail api page

### DIFF
--- a/docs/api/lib-mail.adoc
+++ b/docs/api/lib-mail.adoc
@@ -24,6 +24,10 @@ const mailLib = require('/lib/xp/mail');
 
 You are now ready to use the library functionality.
 
+====
+[NOTE]
+You also need to configure your smtp-server before you can send out email. For details, see <<../deployment/config#mail, the configuration page>>
+====
 
 == Functions
 


### PR DESCRIPTION
It will be useful for developers to find a link to the mail configuration together with the mail-lib api documentation